### PR TITLE
Create comments data structure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
 
       # specify any bash command here prefixed with `run: `
+      - run: mix format --check-formatted
       - run: mix test
 
       - store_test_results:  # upload test results for display in Test Summary

--- a/lib/comments_broccoli/models/comment.ex
+++ b/lib/comments_broccoli/models/comment.ex
@@ -1,0 +1,24 @@
+defmodule CommentsBroccoli.Comment do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias CommentsBroccoli.{Page, Comment}
+
+  schema "comments" do
+    field(:email, :string)
+    field(:message, :string)
+    field(:name, :string)
+
+    belongs_to(:page, Page)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Comment{} = comment, attrs) do
+    comment
+    |> cast(attrs, [:name, :email, :message])
+    |> validate_required([:name, :email, :message])
+  end
+end

--- a/lib/comments_broccoli/models/comment.ex
+++ b/lib/comments_broccoli/models/comment.ex
@@ -19,6 +19,7 @@ defmodule CommentsBroccoli.Comment do
   def changeset(%Comment{} = comment, attrs) do
     comment
     |> cast(attrs, [:name, :email, :message])
-    |> validate_required([:name, :email, :message])
+    |> validate_required([:message])
+    |> assoc_constraint(:page)
   end
 end

--- a/lib/comments_broccoli/models/page.ex
+++ b/lib/comments_broccoli/models/page.ex
@@ -1,0 +1,25 @@
+defmodule CommentsBroccoli.Page do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias CommentsBroccoli.{Website, Page, Comment}
+
+  schema "pages" do
+    field(:slug, :string)
+
+    belongs_to(:website, Website)
+    has_many(:comments, Comment)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Page{} = page, attrs) do
+    page
+    |> cast(attrs, [:slug])
+    |> validate_required([:slug])
+    |> unsafe_validate_unique([:website_id, :slug], CommentsBroccoli.Repo)
+    |> unique_constraint(:slug, name: :pages_website_id_slug_index)
+  end
+end

--- a/lib/comments_broccoli/models/page.ex
+++ b/lib/comments_broccoli/models/page.ex
@@ -19,7 +19,7 @@ defmodule CommentsBroccoli.Page do
     page
     |> cast(attrs, [:slug])
     |> validate_required([:slug])
-    |> unsafe_validate_unique([:website_id, :slug], CommentsBroccoli.Repo)
+    |> assoc_constraint(:website)
     |> unique_constraint(:slug, name: :pages_website_id_slug_index)
   end
 end

--- a/lib/comments_broccoli/models/user.ex
+++ b/lib/comments_broccoli/models/user.ex
@@ -7,7 +7,7 @@ defmodule CommentsBroccoli.User do
 
   import Ecto.Changeset
 
-  alias CommentsBroccoli.Website
+  alias CommentsBroccoli.{User, Website}
 
   schema "users" do
     field(:email, :string)
@@ -21,12 +21,12 @@ defmodule CommentsBroccoli.User do
 
   @required_attrs ~w(email password)a
 
-  def changeset(model, params \\ %{}) do
+  def changeset(%User{} = model, params \\ %{}) do
     model
     |> cast(params, @required_attrs)
   end
 
-  def registration_changeset(model, params) do
+  def registration_changeset(%User{} = model, params) do
     model
     |> changeset(params)
     |> validate_required(@required_attrs)

--- a/lib/comments_broccoli/models/website.ex
+++ b/lib/comments_broccoli/models/website.ex
@@ -3,7 +3,7 @@ defmodule CommentsBroccoli.Website do
 
   import Ecto.Changeset
 
-  alias CommentsBroccoli.User
+  alias CommentsBroccoli.{User, Website, Page}
 
   schema "websites" do
     field(:title, :string)
@@ -11,11 +11,12 @@ defmodule CommentsBroccoli.Website do
     field(:token, :string)
 
     belongs_to(:user, User)
+    has_many(:pages, Page)
 
     timestamps()
   end
 
-  def changeset(model, attrs \\ %{}) do
+  def changeset(%Website{} = model, attrs \\ %{}) do
     model
     |> cast(attrs, [:title, :url])
     |> validate_required([:title, :url])

--- a/priv/repo/migrations/20180302065914_create_pages.exs
+++ b/priv/repo/migrations/20180302065914_create_pages.exs
@@ -1,0 +1,15 @@
+defmodule CommentsBroccoli.Repo.Migrations.CreatePages do
+  use Ecto.Migration
+
+  def change do
+    create table(:pages) do
+      add :slug, :string
+      add :website_id, references(:websites, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:pages, [:website_id])
+    create unique_index(:pages, [:website_id, :slug], name: :pages_website_id_slug_index)
+  end
+end

--- a/priv/repo/migrations/20180302070317_create_comments.exs
+++ b/priv/repo/migrations/20180302070317_create_comments.exs
@@ -1,0 +1,17 @@
+defmodule CommentsBroccoli.Repo.Migrations.CreateComments do
+  use Ecto.Migration
+
+  def change do
+    create table(:comments) do
+      add :name, :string
+      add :email, :citext
+      add :message, :string
+
+      add :page_id, references(:pages, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:comments, [:page_id])
+  end
+end

--- a/test/comments_broccoli/models/comment_test.exs
+++ b/test/comments_broccoli/models/comment_test.exs
@@ -1,0 +1,42 @@
+defmodule CommentsBroccoli.CommentTest do
+  use CommentsBroccoli.DataCase, async: true
+
+  alias CommentsBroccoli.{Repo, Page, Comment}
+
+  describe "changeset/2 when message is missing" do
+    test "is invalid" do
+      changeset = Comment.changeset(%Comment{}, %{})
+      refute changeset.valid?
+
+      {msg, _} = changeset.errors[:message]
+
+      assert msg == "can't be blank"
+    end
+  end
+
+  describe "changeset/2 when page doesn't exist" do
+    test "is invalid" do
+      changeset = Comment.changeset(%Comment{page_id: 1}, %{message: "foo"})
+      assert changeset.valid?
+
+      {:error, changeset} = Repo.insert(changeset)
+      {msg, _} = changeset.errors[:page]
+
+      assert msg == "does not exist"
+    end
+  end
+
+  describe "changeset/2 when message is present and page exists" do
+    setup do
+      {:ok, page} = Repo.insert(%Page{slug: "bar"})
+      %{page: page}
+    end
+
+    test "is valid", %{page: page} do
+      changeset = Comment.changeset(%Comment{page: page}, %{message: "foo"})
+      assert changeset.valid?
+      {result, %Comment{}} = Repo.insert(changeset)
+      assert :ok == result
+    end
+  end
+end

--- a/test/comments_broccoli/models/page_test.exs
+++ b/test/comments_broccoli/models/page_test.exs
@@ -1,0 +1,55 @@
+defmodule CommentsBroccoli.PageTest do
+  use CommentsBroccoli.DataCase, async: true
+
+  alias CommentsBroccoli.{Repo, Page}
+
+  describe "changeset/2 when missing slug" do
+    test "is invalid" do
+      changeset = Page.changeset(%Page{website_id: 1}, %{})
+      refute changeset.valid?
+
+      {msg, _} = changeset.errors[:slug]
+      assert msg == "can't be blank"
+    end
+  end
+
+  describe "changeset/2 when website doesn't exist" do
+    test "is invalid" do
+      changeset = Page.changeset(%Page{website_id: 1}, %{slug: "foo"})
+      assert changeset.valid?
+
+      {:error, changeset} = Repo.insert(changeset)
+      {msg, _} = changeset.errors[:website]
+
+      assert msg == "does not exist"
+    end
+  end
+
+  describe "changeset/2 when slug already exists" do
+    setup [:with_user, :with_website]
+
+    setup %{website: website} do
+      {:ok, _} = Repo.insert(%Page{website_id: website.id, slug: "page-test-duplicate-slug"})
+      :ok
+    end
+
+    test "is invalid", %{website: website} do
+      changeset =
+        Page.changeset(%Page{website_id: website.id}, %{slug: "page-test-duplicate-slug"})
+
+      assert changeset.valid?
+
+      {:error, changeset} = Repo.insert(changeset)
+      {msg, _} = changeset.errors[:slug]
+
+      assert msg == "has already been taken"
+    end
+  end
+
+  describe "changeset/2 when slug doesn't exists" do
+    test "is valid" do
+      changeset = Page.changeset(%Page{website_id: 1}, %{slug: "page-test-unique-slug"})
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/comments_broccoli/models/website_test.exs
+++ b/test/comments_broccoli/models/website_test.exs
@@ -16,7 +16,7 @@ defmodule CommentsBroccoli.WebsiteTest do
     end
   end
 
-  describe "changeset/2 when attributes are presetn" do
+  describe "changeset/2 when attributes are present" do
     test "is valid" do
       changeset = Website.changeset(%Website{}, %{title: "foo", url: "foo"})
       assert changeset.valid?


### PR DESCRIPTION
Creates a data structure for the comments with proper associations. So in the end we will have something like this:

```elixir
Website -> Page -> Comments
```

where Pages will get created on the fly, transparently while creating comments, later we can have page creation from within owner UI in order to follow comments per page, or filter them out, etc.